### PR TITLE
Support for Playlist Tags EXT-X-PLAYLIST-TYPE & EXT-X-STREAM-INF

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ According to [HLS draft version 23](https://tools.ietf.org/html/draft-pantos-htt
     - [x] EXT-X-MEDIA-SEQUENCE
     - [x] EXT-X-DISCONTINUITY-SEQUENCE
     - [x] EXT-X-ENDLIST
-    - [ ] EXT-X-PLAYLIST-TYPE
+    - [x] EXT-X-PLAYLIST-TYPE
     - [ ] EXT-X-I-FRAMES-ONLY
 * Master Playlist Tags
     - [ ] EXT-X-MEDIA
-    - [ ] EXT-X-STREAM-INF
+    - [x] EXT-X-STREAM-INF
     - [ ] EXT-X-I-FRAME-STREAM-INF
     - [ ] EXT-X-SESSION-DATA
     - [ ] EXT-X-SESSION-KEY

--- a/src/M3u8.php
+++ b/src/M3u8.php
@@ -15,6 +15,7 @@ class M3u8 extends AbstractContainer
 {
     private $m3uTag;
     private $versionTag;
+    private $playlistTypeTag;
     private $targetDurationTag;
     private $mediaSequenceTag;
     private $discontinuitySequenceTag;
@@ -25,6 +26,7 @@ class M3u8 extends AbstractContainer
     {
         $this->m3uTag = new Tag\M3uTag();
         $this->versionTag = new Tag\VersionTag();
+        $this->playlistTypeTag = new Tag\PlaylistTypeTag();
         $this->targetDurationTag = new Tag\TargetDurationTag();
         $this->mediaSequenceTag = new Tag\MediaSequenceTag();
         $this->discontinuitySequenceTag = new Tag\DiscontinuitySequenceTag();
@@ -47,6 +49,16 @@ class M3u8 extends AbstractContainer
     public function getVersion()
     {
         return $this->versionTag->getVersion();
+    }
+
+    public function getPlaylistTypeTag()
+    {
+        return $this->playlistTypeTag;
+    }
+
+    public function getPlaylistType()
+    {
+        return $this->playlistTypeTag->getPlaylistType();
     }
 
     public function getTargetDurationTag()
@@ -107,6 +119,7 @@ class M3u8 extends AbstractContainer
         return [
             $this->m3uTag,
             $this->versionTag,
+            $this->playlistTypeTag,
             $this->targetDurationTag,
             $this->mediaSequenceTag,
             $this->discontinuitySequenceTag,

--- a/src/Segment.php
+++ b/src/Segment.php
@@ -16,6 +16,7 @@ class Segment extends AbstractContainer
     private $extinfTag;
     private $byteRangeTag;
     private $discontinuityTag;
+    private $streamTags;
     private $keyTags;
     private $uri;
 
@@ -27,6 +28,7 @@ class Segment extends AbstractContainer
         $this->extinfTag = new Tag\ExtinfTag($m3u8Version);
         $this->byteRangeTag = new Tag\ByteRangeTag();
         $this->discontinuityTag = new Tag\DiscontinuityTag();
+        $this->streamTags = new StreamTags();
         $this->keyTags = new KeyTags();
         $this->uri = new Uri();
     }
@@ -95,6 +97,14 @@ class Segment extends AbstractContainer
     }
 
     /**
+     * @return Chrisyue\PhpM3u8\StreamTags
+     */
+    public function getStreamTags()
+    {
+        return $this->streamTags;
+    }
+
+    /**
      * @return Chrisyue\PhpM3u8\KeyTags
      */
     public function getKeyTags()
@@ -113,6 +123,7 @@ class Segment extends AbstractContainer
     protected function getComponents()
     {
         return [
+            $this->streamTags,
             $this->keyTags,
             $this->extinfTag,
             $this->byteRangeTag,

--- a/src/StreamTags.php
+++ b/src/StreamTags.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the PhpM3u8 package.
+ *
+ * (c) Chrisyue <http://chrisyue.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Chrisyue\PhpM3u8;
+
+class StreamTags implements DumpableInterface, \Iterator, \ArrayAccess
+{
+    private $tags = [];
+    private $position;
+
+    public function rewind()
+    {
+        $this->position = 0;
+    }
+
+    public function current()
+    {
+        return $this->tags[$this->position];
+    }
+
+    public function key()
+    {
+        return $this->position;
+    }
+
+    public function next()
+    {
+        ++$this->position;
+    }
+
+    /**
+     * @return bool
+     */
+    public function valid()
+    {
+        return isset($this->tags[$this->position]);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if (!is_object($value) || !$value instanceof Tag\StreamTag) {
+            throw new \InvalidArgumentException('Expected $value of class Chrisyue\PhpM3u8\Tag\StreamTag');
+        }
+
+        if (is_null($offset)) {
+            $this->add($value);
+
+            return;
+        }
+
+        $this->tags[$offset] = $value;
+    }
+
+    /**
+     * @return Chrisyue\PhpM3u8\Tag\StreamTag
+     */
+    public function offsetGet($offset)
+    {
+        return $this->tags[$offset];
+    }
+
+    /**
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->tags[$offset]);
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->tags[$offset]);
+    }
+
+    public function add(Tag\StreamTag $tag)
+    {
+        $this->tags[] = $tag;
+    }
+
+    public function readLines(array &$lines)
+    {
+        while (true) {
+            $tag = new Tag\StreamTag();
+            $tag->readLines($lines);
+
+            //if (null === $tag->getBandwidth()) {
+            if (null === $tag->getProgramId()) {
+                return;
+            }
+
+            $this->tags[] = $tag;
+        }
+    }
+
+    public function dump()
+    {
+        return implode("\n", array_map(function (Tag\StreamTag $tag) {
+            return $tag->dump();
+        }, $this->tags));
+    }
+}

--- a/src/Tag/DiscontinuitySequenceTag.php
+++ b/src/Tag/DiscontinuitySequenceTag.php
@@ -15,7 +15,7 @@ class DiscontinuitySequenceTag extends AbstractTag
 {
     use SingleValueTagTrait;
 
-    private $discontinuitySequence = 0;
+    private $discontinuitySequence;
 
     const TAG_IDENTIFIER = '#EXT-X-DISCONTINUITY-SEQUENCE';
 
@@ -33,11 +33,14 @@ class DiscontinuitySequenceTag extends AbstractTag
 
     public function dump()
     {
+        if (empty($this->discontinuitySequence) && $this->discontinuitySequence !== '0') {
+            return;
+        }
         return sprintf('%s:%d', self::TAG_IDENTIFIER, $this->discontinuitySequence);
     }
 
     protected function read($line)
     {
-        $this->discontinuitySequence = (int) self::extractValue($line);
+        $this->discontinuitySequence = self::extractValue($line);
     }
 }

--- a/src/Tag/MediaSequenceTag.php
+++ b/src/Tag/MediaSequenceTag.php
@@ -15,7 +15,7 @@ class MediaSequenceTag extends AbstractTag
 {
     use SingleValueTagTrait;
 
-    private $mediaSequence = 0;
+    private $mediaSequence;
 
     const TAG_IDENTIFIER = '#EXT-X-MEDIA-SEQUENCE';
 
@@ -33,11 +33,14 @@ class MediaSequenceTag extends AbstractTag
 
     public function dump()
     {
+        if (empty($this->mediaSequence) && $this->mediaSequence !== '0') {
+            return;
+        }
         return sprintf('%s:%d', self::TAG_IDENTIFIER, $this->mediaSequence);
     }
 
     protected function read($line)
     {
-        $this->mediaSequence = (int) self::extractValue($line);
+        $this->mediaSequence = self::extractValue($line);
     }
 }

--- a/src/Tag/PlaylistTypeTag.php
+++ b/src/Tag/PlaylistTypeTag.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the PhpM3u8 package.
+ *
+ * (c) Chrisyue <http://chrisyue.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Chrisyue\PhpM3u8\Tag;
+
+class PlaylistTypeTag extends AbstractTag
+{
+    use SingleValueTagTrait;
+
+    private $playlist_type;
+
+    const TAG_IDENTIFIER = '#EXT-X-PLAYLIST-TYPE';
+
+    public function setPlaylistType($playlist_type)
+    {
+        $this->playlist_type = $playlist_type;
+
+        return $this;
+    }
+
+    public function getPlaylistType()
+    {
+        return $this->playlist_type;
+    }
+
+    public function dump()
+    {
+        if (empty($this->playlist_type)) {
+            return;
+        }
+        return sprintf('%s:%s', self::TAG_IDENTIFIER, $this->playlist_type);
+    }
+
+    protected function read($line)
+    {
+        $this->playlist_type = (string) self::extractValue($line);
+    }
+}

--- a/src/Tag/StreamTag.php
+++ b/src/Tag/StreamTag.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the PhpM3u8 package.
+ *
+ * (c) Chrisyue <http://chrisyue.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Chrisyue\PhpM3u8\Tag;
+
+class StreamTag extends AbstractTag
+{
+    use SingleValueTagTrait;
+
+    const TAG_IDENTIFIER = '#EXT-X-STREAM-INF';
+
+    /**
+     * @var string
+     */
+    private $programId;
+
+    /**
+     * @var string
+     */
+    private $bandwidth;
+
+    /**
+     * @var string
+     */
+    private $resolution;
+
+    /**
+     * @var string
+     */
+    private $codecs;
+
+    /**
+     * @param string
+     *
+     * @return self
+     */
+    public function setProgramId($programId)
+    {
+        $this->programId = $programId;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProgramId()
+    {
+        return $this->programId;
+    }
+
+    /**
+     * @param string
+     *
+     * @return self
+     */
+    public function setBandwidth($bandwidth)
+    {
+        $this->bandwidth = $bandwidth;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBandwidth()
+    {
+        return $this->bandwidth;
+    }
+
+    /**
+     * @param string
+     *
+     * @return self
+     */
+    public function setResolution($resolution)
+    {
+        $this->resolution = $resolution;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResolution()
+    {
+        return $this->resolution;
+    }
+
+    /**
+     * @param string
+     *
+     * @return self
+     */
+    public function setCodecs($codecs)
+    {
+        $this->codecs = $codecs;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCodecs()
+    {
+        return $this->codecs;
+    }
+
+    public function dump()
+    {
+        $attrs = [];
+        foreach (get_object_vars($this) as $prop => $value) {
+            if (empty($value)) {
+                continue;
+            }
+
+            if ('codecs' === $prop) {
+                $attrs[] = sprintf('%s="%s"', strtoupper($prop), $value);
+                continue;
+            }
+
+            if ('programId' === $prop) {
+                $attrs[] = sprintf('%s=%s', 'PROGRAM-ID', $value);
+                continue;
+            }
+
+            $attrs[] = sprintf('%s=%s', strtoupper($prop), $value);
+        }
+
+        if (empty($attrs)) {
+            return;
+        }
+
+        return sprintf('%s:%s', self::TAG_IDENTIFIER, implode(',', $attrs));
+    }
+
+    protected function read($line)
+    {
+        $attrs = preg_split("/,(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))/", self::extractValue($line));
+        $attributes = [];
+        foreach ($attrs as $attr) {
+            list($key, $value) = explode('=', $attr);
+            $attributes[$key] = trim($value);
+        }
+
+        foreach (get_object_vars($this) as $prop => $value) {
+            $key = strtoupper($prop);
+            if (isset($attributes[$key])) {
+                if ('codecs' === $prop) {
+                    $this->$prop = trim($attributes[$key], '",');
+                    continue;
+                }
+                $this->$prop = trim($attributes[$key], ',');
+            }
+        }
+        if (isset($attributes['PROGRAM-ID'])) {
+            $this->programId = trim($attributes['PROGRAM-ID'], ',');
+        }
+    }
+}

--- a/src/Tag/TargetDurationTag.php
+++ b/src/Tag/TargetDurationTag.php
@@ -33,11 +33,14 @@ class TargetDurationTag extends AbstractTag
 
     public function dump()
     {
+        if (empty($this->targetDuration) && $this->targetDuration !== '0') {
+            return;
+        }
         return sprintf('%s:%d', self::TAG_IDENTIFIER, $this->targetDuration);
     }
 
     protected function read($line)
     {
-        $this->targetDuration = (int) self::extractValue($line);
+        $this->targetDuration = self::extractValue($line);
     }
 }


### PR DESCRIPTION
Hi, I needed to parse and dump playlists so I added EXT-X-PLAYLIST-TYPE & EXT-X-STREAM-INF support to your project.  I hope I extended it in a fashion that fits with the overall pattern you were using. I did not add all the fields in the RFC for EXT-X-STREAM-INF, but I added the required and most popular ones.