### PR TITLE
Convert media and discontinuity sequence to int, to fix the bug where…

### DIFF
--- a/src/Segments.php
+++ b/src/Segments.php
@@ -122,8 +122,8 @@ class Segments implements DumpableInterface, \Iterator, \ArrayAccess
 
     public function readLines(array &$lines)
     {
-        $mediaSequence = $this->m3u8->getMediaSequence();
-        $discontinuitySequence = $this->m3u8->getDiscontinuitySequence();
+        $mediaSequence = (int) $this->m3u8->getMediaSequence();
+        $discontinuitySequence = (int) $this->m3u8->getDiscontinuitySequence();
         while (true) {
             $segment = new Segment($this->m3u8->getVersion());
             $segment->readLines($lines);


### PR DESCRIPTION
… the values are null for the first segments of a playlist without those tags