### PR TITLE
Supporting Inf lines without human readable title

### DIFF
--- a/src/Data/Value/Tag/Inf.php
+++ b/src/Data/Value/Tag/Inf.php
@@ -41,10 +41,10 @@ class Inf
     }
 
     public static function fromString($string)
-    {
-        [$duration, $title] = explode(',', $string);
+    {        
+        $parts = explode(',', $string);
 
-        return new self($duration, $title);
+        return new self($parts[0], $parts[1] ?? null);
     }
 
     public function getDuration()


### PR DESCRIPTION
Changing code to ensure that for cases when the optional human-readable title does not exist in an Inf Line, the code does not fail. Relevant RFC [section](https://www.rfc-editor.org/rfc/rfc8216#section-4.3.2.1)

**Env where the error was encountered:**
OS: Windows 10
PHP Version: PHP 7.4.x
m3u8 library: 4.0.x